### PR TITLE
Add table, scaler and OHE

### DIFF
--- a/hammerfin/processing/__init__.py
+++ b/hammerfin/processing/__init__.py
@@ -1,0 +1,1 @@
+from ._scaling import Scaler

--- a/hammerfin/processing/__init__.py
+++ b/hammerfin/processing/__init__.py
@@ -1,1 +1,2 @@
+from ._one_hot_encoding import OneHotEncoder
 from ._scaling import Scaler

--- a/hammerfin/processing/_one_hot_encoding.py
+++ b/hammerfin/processing/_one_hot_encoding.py
@@ -1,0 +1,77 @@
+import logging
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class OneHotEncoder:
+    """
+    OneHotEncoder class for pandas DataFrame.
+
+    Parameters
+    ----------
+    max_unique : int, optional
+        The maximum number of unique values allowed for a categorical variable.
+    skip : list of str, optional
+        List of column names to skip while one-hot encoding, by default None
+    """
+
+    def __init__(self, max_unique=10, skip=None):
+        self.max_unique = max_unique
+        self.skip = skip or []
+        self.columns = {}
+
+    def __str__(self):
+        return f"OneHotEncoder(max_unique={self.max_unique}, skip={self.skip})"
+
+    def __repr__(self):
+        return f"OneHotEncoder(max_unique={self.max_unique}, skip={self.skip})"
+
+    def fit(self, X):
+        """
+        Fit the OneHotEncoder to the data.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            A pandas DataFrame to fit the OneHotEncoder
+        """
+        for col in X.columns:
+            if col in self.skip:
+                continue
+            if not pd.api.types.is_numeric_dtype(X[col]):
+                if X[col].nunique() > self.max_unique:
+                    raise ValueError(
+                        f"Column '{col}' has more than {self.max_unique} unique values. "
+                        f"Please drop this column or reduce its unique values."
+                    )
+                self.columns[col] = X[col].unique().tolist()
+        return self
+
+    def transform(self, X):
+        """
+        Transform the data using the fitted OneHotEncoder.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            A pandas DataFrame to transform
+
+        Returns
+        -------
+        pd.DataFrame
+            Transformed pandas DataFrame
+        """
+        X = X.copy()
+        for col, values in self.columns.items():
+            for unique_value in X[col].unique().tolist():
+                if unique_value not in values:
+                    logger.warning(
+                        f"HammerFin - OneHotEncoder - Unseen category '{unique_value}' in column '{col}' during 'fit'. "
+                        f"This category will be ignored."
+                    )
+                else:
+                    X[f"{col}_{unique_value}"] = (X[col] == unique_value).astype(int)
+            X.drop(col, axis=1, inplace=True)
+        return X

--- a/hammerfin/processing/_scaling.py
+++ b/hammerfin/processing/_scaling.py
@@ -1,0 +1,76 @@
+import pandas as pd
+
+
+# pylint: disable=fixme
+# TODO: take method as a dict of column names and methods
+class Scaler:
+    """
+    Scaler class for normalizing pandas DataFrame.
+
+    Parameters
+    ----------
+    method : str, optional
+        The method to use for scaling - "standard" or "minmax", by default "standard"
+    skip : list of str, optional
+        List of column names to skip while scaling, by default None
+    """
+
+    def __init__(self, method="standard", skip=None):
+        self.method = method
+        self.skip = skip or []
+        self.params = {}
+
+    def __str__(self):
+        return f"Scaler(method={self.method}, skip={self.skip})"
+
+    def __repr__(self):
+        return f"Scaler(method={self.method}, skip={self.skip})"
+
+    def fit(self, X):
+        """
+        Fit the Scaler to the data.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            A pandas DataFrame to fit the Scaler
+        """
+        for col in X.columns:
+            if col in self.skip:
+                continue
+            if not pd.api.types.is_numeric_dtype(X[col]):
+                self.skip.append(col)
+                continue
+            if self.method == "standard":
+                self.params[col] = {"method": "standard", "mean": X[col].mean(), "std": X[col].std()}
+            elif self.method == "minmax":
+                self.params[col] = {"method": "minmax", "min": X[col].min(), "max": X[col].max()}
+            else:
+                raise ValueError("Scaler method must be 'standard' or 'minmax'")
+        return self
+
+    def transform(self, X):
+        """
+        Transform the data using the fitted Scaler.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            A pandas DataFrame to transform
+
+        Returns
+        -------
+        pd.DataFrame
+            Transformed pandas DataFrame
+        """
+        X = X.copy()
+        for col in X.columns:
+            if col in self.skip:
+                continue
+            if self.method == "standard":
+                if self.params[col]["std"] != 0:
+                    X[col] = (X[col] - self.params[col]["mean"]) / self.params[col]["std"]
+            elif self.method == "minmax":
+                if self.params[col]["max"] != self.params[col]["min"]:
+                    X[col] = (X[col] - self.params[col]["min"]) / (self.params[col]["max"] - self.params[col]["min"])
+        return X

--- a/hammerfin/processing/_scaling.py
+++ b/hammerfin/processing/_scaling.py
@@ -1,4 +1,8 @@
+import logging
+
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 class Scaler:
@@ -76,7 +80,17 @@ class Scaler:
             if method == "standard":
                 if self.params[col]["std"] != 0:
                     X[col] = (X[col] - self.params[col]["mean"]) / self.params[col]["std"]
+                else:
+                    logger.warning(
+                        f"HammerFin - Scaler - Column '{col}' had standard deviation of 0 during `fit`. "
+                        f"This column will not be changed."
+                    )
             elif method == "minmax":
                 if self.params[col]["max"] != self.params[col]["min"]:
                     X[col] = (X[col] - self.params[col]["min"]) / (self.params[col]["max"] - self.params[col]["min"])
+                else:
+                    logger.warning(
+                        f"HammerFin - Scaler - Column '{col}' had equal max and min values during `fit`. "
+                        f"This column will not be changed."
+                    )
         return X

--- a/hammerfin/table/__init__.py
+++ b/hammerfin/table/__init__.py
@@ -1,4 +1,4 @@
-from _financial_methods import (
+from ._financial_methods import (
     calmar,
     cumulative,
     drawdowns,

--- a/hammerfin/table/_financial_methods.py
+++ b/hammerfin/table/_financial_methods.py
@@ -5,24 +5,21 @@ __available_indicators__ = ["sharpe", "sortino", "calmar", "max_drawdown"]
 
 
 def assert_ts(func):
-    """Assert that the method is applied to a Table object with datetime index"""
+    """Assert that the method is applied to an object with datetime index"""
 
     def wrapper(*args, **kwargs):
         """Wrapper function for assert_ts"""
-        # pylint: disable = import-outside-toplevel, cyclic-import
-        from ._table import Table, TableSeries
 
-        if not isinstance(args[0], Table) and not isinstance(args[0], TableSeries):
-            raise ValueError("Method can only be applied to Table object")
         if not pd.api.types.is_datetime64_any_dtype(args[0].index):
-            raise ValueError("Method can only be applied to Table with datetime index")
+            raise ValueError("Method can only be applied to an object with datetime index")
         return func(*args, **kwargs)
 
     return wrapper
 
 
 def daily_resampler(self):
-    """Resample to daily frequency and return last value"""
+    """Resample to daily frequency"""
+    print(self.resample("1D").last().fillna(method="ffill"))
     return self.resample("1D").last().fillna(method="ffill")  # if oversampling
 
 

--- a/hammerfin/table/_financial_methods.py
+++ b/hammerfin/table/_financial_methods.py
@@ -19,7 +19,6 @@ def assert_ts(func):
 
 def daily_resampler(self):
     """Resample to daily frequency"""
-    print(self.resample("1D").last().fillna(method="ffill"))
     return self.resample("1D").last().fillna(method="ffill")  # if oversampling
 
 

--- a/hammerfin/table/_table.py
+++ b/hammerfin/table/_table.py
@@ -198,9 +198,9 @@ class Table(pd.DataFrame):
             X = step.transform(X)
         return X
 
-    def scale(self, method="standard", skip=None):
+    def scale(self, *args, **kwargs):
         """Scale the Table"""
-        scaler = Scaler(method=method, skip=skip).fit(self)
+        scaler = Scaler(*args, **kwargs).fit(self)
         self.processing_steps.append(scaler)
         transformed = scaler.transform(self)
         self.update(transformed)

--- a/hammerfin/table/_table.py
+++ b/hammerfin/table/_table.py
@@ -1,7 +1,11 @@
+import logging
+import re
+
 import pandas as pd
 
 from ..dtypes._currency import assert_currency_dtype
 from ..dtypes._fin_dtype import FinDType, assert_fin_dtype
+from ..utils.pandas_loader import load_data
 from ._financial_methods import (
     calmar,
     cumulative,
@@ -11,6 +15,10 @@ from ._financial_methods import (
     sharpe,
     sortino,
 )
+
+logger = logging.getLogger(__name__)
+
+# pylint: disable=logging-fstring-interpolation, too-many-branches
 
 
 class TableSeries(pd.Series):
@@ -66,5 +74,95 @@ class TableSeries(pd.Series):
         return pd.Series(self)
 
 
-class Table:
+class Table(pd.DataFrame):
     """Overloaded pd.DataFrame class"""
+
+    @property
+    def _constructor(self):
+        return Table
+
+    @property
+    def _constructor_sliced(self):
+        return TableSeries
+
+    def __init__(
+        self,
+        data=None,
+        dtype=None,
+        copy=False,
+        timeseries=True,
+        verbose=False,
+        parse_dates=False,
+        **kwargs,
+    ):
+        if isinstance(data, str):
+            data = load_data(data, **kwargs)
+            super().__init__(data)
+        else:
+            super().__init__(data=data, dtype=dtype, copy=copy, **kwargs)
+
+        self.is_stationnary = False
+        self.is_normalized = False
+        nb_rows, nb_cols = self.shape
+
+        if verbose:
+            print(f"Table has {nb_rows} rows and {nb_cols} columns")
+            print(f"Table has {self.memory_usage().sum()/1e6} MB of memory")
+            print(f"Table columns are {[*self.columns]}")
+            nb_nan = self.isna().sum().sum()
+            if nb_nan > 0:
+                logger.warning(f"Table contains {nb_nan} NaN values")
+            else:
+                print("Table has no NaN values")
+
+        if timeseries and not pd.api.types.is_datetime64_any_dtype(self.index) and parse_dates:
+            found = False
+            for col in self.columns:
+                first_value = self[col][0]
+                if isinstance(first_value, str):
+                    if re.match(r"\d{4}-\d{2}-\d{2}", first_value) or re.match(r"\d{2}/\d{2}/\d{4}", first_value):
+                        self[col] = pd.to_datetime(self[col])
+                        self.set_index(col, inplace=True)
+                        logger.info(f"Column {col} is set as index")
+                        found = True
+                        break
+                elif isinstance(first_value, int):
+                    if first_value > 1e9:
+                        self[col] = pd.to_datetime(self[col], unit="s")
+                        self.set_index(col, inplace=True)
+                        logger.info(f"Column {col} is set as index")
+                        found = True
+                        break
+
+                elif pd.api.types.is_datetime64_any_dtype(first_value):
+                    self.set_index(col, inplace=True)
+                    logger.info(f"Column {col} is set as index")
+                    found = True
+                    break
+            self.index.name = "date"
+            if not found:
+                logger.info("No datetime column found")
+
+    def __type__(self):
+        return "Table"
+
+    def __repr__(self):
+        return super().__repr__() + " Table Object"
+
+    def __str__(self):
+        return super().__str__() + " Table Object"
+
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls, *args, **kwargs)
+
+    def as_df(self):
+        """Return the Table as a pandas DataFrame"""
+        return pd.DataFrame(self)
+
+    sharpe = sharpe
+    calmar = calmar
+    sortino = sortino
+    drawdowns = drawdowns
+    max_drawdown = max_drawdown
+    indicators = indicators
+    cumulative = cumulative

--- a/hammerfin/table/_table.py
+++ b/hammerfin/table/_table.py
@@ -97,6 +97,21 @@ class Table(pd.DataFrame):
     def _constructor_sliced(self):
         return TableSeries
 
+    def __setitem__(self, key, value):
+        if isinstance(value, TableSeries) and value.fin_dtype is not None:
+            dtype_dict = self.__dict__.get("_tableseries_dtypes", {})
+            dtype_dict[key] = value.fin_dtype
+            self.__dict__["_tableseries_dtypes"] = dtype_dict
+        super().__setitem__(key, value)
+
+    def __getitem__(self, item):
+        value = super().__getitem__(item)
+        if isinstance(value, pd.Series):
+            fin_dtype = self.__dict__.get("_tableseries_dtypes", {}).get(item)
+            if fin_dtype is not None:
+                value = TableSeries(value, dtype=fin_dtype)
+        return value
+
     def __init__(
         self,
         data=None,

--- a/hammerfin/table/_table.py
+++ b/hammerfin/table/_table.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from ..dtypes._currency import assert_currency_dtype
 from ..dtypes._fin_dtype import FinDType, assert_fin_dtype
-from ..processing import Scaler
+from ..processing import OneHotEncoder, Scaler
 from ..utils.pandas_loader import load_data
 from ._financial_methods import (
     calmar,
@@ -18,8 +18,6 @@ from ._financial_methods import (
 )
 
 logger = logging.getLogger(__name__)
-
-# pylint: disable=logging-fstring-interpolation, too-many-branches
 
 
 def assert_hf(func):
@@ -203,5 +201,13 @@ class Table(pd.DataFrame):
         scaler = Scaler(*args, **kwargs).fit(self)
         self.processing_steps.append(scaler)
         transformed = scaler.transform(self)
+        self.update(transformed)
+        return self
+
+    def one_hot_encode(self, *args, **kwargs):
+        """One-hot-encode the Table"""
+        one_hot_encoder = OneHotEncoder(*args, **kwargs).fit(self)
+        self.processing_steps.append(one_hot_encoder)
+        transformed = one_hot_encoder.transform(self)
         self.update(transformed)
         return self

--- a/hammerfin/utils/pandas_loader.py
+++ b/hammerfin/utils/pandas_loader.py
@@ -1,0 +1,31 @@
+import os
+
+import pandas as pd
+
+
+def load_data(file_path, **kwargs):
+    """
+    Load data into pandas DataFrame from a file path
+
+    Supported extensions are .csv, .xls, .xlsx, .json, .pkl, .feather, .parquet
+    """
+
+    _, file_extension = os.path.splitext(file_path)
+    file_extension = file_extension.lower()
+
+    if file_extension == ".csv":
+        return pd.read_csv(file_path, **kwargs)
+    if file_extension in [".xls", ".xlsx"]:
+        return pd.read_excel(file_path, **kwargs)
+    if file_extension == ".json":
+        return pd.read_json(file_path, **kwargs)
+    if file_extension == ".pkl":
+        return pd.read_pickle(file_path, **kwargs)
+    if file_extension == ".feather":
+        return pd.read_feather(file_path, **kwargs)
+    if file_extension == ".parquet":
+        return pd.read_parquet(file_path, **kwargs)
+    raise ValueError(
+        f"""Unsupported file extension: {file_extension}.
+Supported extensions are .csv, .xls, .xlsx, .json, .pkl, .feather, .parquet"""
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ disable = """
     missing-module-docstring,
     import-error,
     too-few-public-methods,
+    logging-fstring-interpolation,
 """
 good-names = "i,j,k,x,y,z,ex,Run,_,e,_E,X"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ disable = """
     import-error,
     too-few-public-methods,
 """
-good-names = "i,j,k,x,y,z,ex,Run,_,e,_E"
+good-names = "i,j,k,x,y,z,ex,Run,_,e,_E,X"
 
 [tool.pylint.MASTER]
 ignore-paths = [


### PR DESCRIPTION
## Adds

- Table class
- Scaler class & corresponding .scale() method
- OneHotEncoder class & corresponding .one_hot_encode() method

Processing steps are added as fitted objects in the `self.processing_steps` list when called.
You can then use this processing list to apply the processing of the training set to the test set - as long as column names match.

## Examples

- Creation and scaling
```python
from hammerfin.table._table import Table

df = Table(
    data={
        "col1": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
        "col2": [5, 3, 3, 2, 5, 6, 7, 10, 9, 10],
        "col3": [-1, -2, -3, -4, -5, -6, -7, -8, -9, -10],
        "col4": ["a", "b", "a", "a", "b", "c", "a", "e", "b", "b"],
        "col5": [0, 0, 0, 0, 0, 0, 1, 2, 3, 4]
    },
    index=pd.date_range("2020-01-01", periods=10),
)

X_train = df.iloc[:5]
X_test = df.iloc[5:]

# Process train dataset
X_train = X_train.scale(method={"col3": "minmax"}, default_method="standard")
X_train = X_train.one_hot_encode()

# Apply train processing to test dataset
X_test = X_train.apply_processing(X_test)

print(X_test)

# Scales col1 and col2
# Scaling automatically skips col4 (categorical) and col5 (constant)
# One-hot-encoding encodes col4
```

<img width="836" alt="image" src="https://github.com/QuantMates/hammerfin/assets/60552083/19bae776-8755-4a96-9a45-86bb31e58eb5">

- Compatibility with custom dtypes
```python
curr_series = TableSeries(
    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
    dtype=Currency("USD"),
    index=pd.date_range("2020-01-01", periods=10),
)

df["curr"] = curr_series
print(df["curr"])

# Custom fin-dtype Series
```
<img width="280" alt="image" src="https://github.com/QuantMates/hammerfin/assets/60552083/95ebe825-b5ab-4096-b5de-60e13701e1ee">
